### PR TITLE
feat: 房间事件改为消费后端聚合摘要

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-trtc-conference",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "用于实现一个基于trtc的视频会议系统",
   "scripts": {
     "init": "husky",

--- a/src/components/Apis/getApis.js
+++ b/src/components/Apis/getApis.js
@@ -66,6 +66,10 @@ const getApis = options => {
       url: `${prefix}/getTrtcInstanceEvents`,
       method: 'GET'
     },
+    getTrtcRoomEventsSummary: {
+      url: `${prefix}/getTrtcRoomEventsSummary`,
+      method: 'GET'
+    },
     createConference: {
       url: `${prefix}/create`,
       method: 'POST'

--- a/src/components/App/ConferenceMain/index.js
+++ b/src/components/App/ConferenceMain/index.js
@@ -304,7 +304,9 @@ const Conference = createWithRemoteLoader({
     const collector = createCollector(data => {
       return ajax(
         Object.assign({}, apis.recordAITranscription, {
-          data: { records: data }
+          data: { records: data },
+          // 会议结束后退房时仍会 flush 上报，服务端会返回"会议已结束"错误，静默处理不打扰用户
+          showError: false
         })
       );
     });
@@ -315,7 +317,8 @@ const Conference = createWithRemoteLoader({
         }
         return ajax(
           Object.assign({}, apis.recordClientEvents, {
-            data: { events: data }
+            data: { events: data },
+            showError: false
           })
         );
       },

--- a/src/components/App/pages/Detail/index.js
+++ b/src/components/App/pages/Detail/index.js
@@ -59,7 +59,8 @@ const Detail = createWithRemoteLoader({
                   inviteMember: apis[name].inviteMember,
                   removeMember: apis[name].removeMember,
                   joinConference: apis[name].joinConference,
-                  getTrtcInstanceEvents: apis[name].getTrtcInstanceEvents
+                  getTrtcInstanceEvents: apis[name].getTrtcInstanceEvents,
+                  getTrtcRoomEventsSummary: apis[name].getTrtcRoomEventsSummary
                 }}
               />
             );

--- a/src/components/App/pages/Home/index.js
+++ b/src/components/App/pages/Home/index.js
@@ -124,6 +124,7 @@ const Home = createWithRemoteLoader({
                   inviteMember: Object.assign(apis[name].inviteMemberFromUser),
                   getMemberShorten: apis[name].getMemberShorten,
                   getTrtcInstanceEvents: apis[name].getTrtcInstanceEvents,
+                  getTrtcRoomEventsSummary: apis[name].getTrtcRoomEventsSummary,
                   getAiTranscriptionContent: async ({ id }) => {
                     const { data: resData } = await ajax(
                       Object.assign({}, apis[name].getAiTranscriptionContent, {

--- a/src/components/ConferenceInfo/ConferenceDetail.js
+++ b/src/components/ConferenceInfo/ConferenceDetail.js
@@ -259,33 +259,23 @@ export const ConferenceDetailInner = createWithRemoteLoader({
     return member?.nickname || member?.email || formatMessage({ id: 'DefaultUser' });
   };
   const showTrtcRoomEvents = async () => {
-    const perPage = 200;
-    const events = [];
-    let currentPage = 1;
-    // 按 totalCount 翻页拉全事件，只取第一页会截断会议后半段数据
-    while (true) {
-      const { data: resData } = await ajax(
-        Object.assign({}, apis?.getTrtcInstanceEvents, {
-          params: { id, perPage, currentPage }
-        })
-      );
-      if (resData.code !== 0) {
-        return;
-      }
-      const pageData = resData.data?.pageData || [];
-      events.push(...pageData);
-      const totalCount = resData.data?.totalCount ?? 0;
-      if (pageData.length === 0 || events.length >= totalCount) {
-        break;
-      }
-      currentPage += 1;
+    if (!apis?.getTrtcRoomEventsSummary) {
+      return;
+    }
+    const { data: resData } = await ajax(
+      Object.assign({}, apis.getTrtcRoomEventsSummary, {
+        params: { id }
+      })
+    );
+    if (resData.code !== 0) {
+      return;
     }
     modal({
       title: formatMessage({ id: 'TrtcRoomEvents' }),
       footer: null,
       width: isMobile ? '100%' : 860,
       children: (
-        <RoomEvents id={id} name={name} status={status} members={members} events={events} />
+        <RoomEvents id={id} name={name} status={status} members={members} data={resData.data} />
       )
     });
   };
@@ -657,7 +647,7 @@ export const ConferenceDetailInner = createWithRemoteLoader({
             </div>
           )}
 
-          {(status === 1 || (status === 0 && !isBeforeStart)) && apis?.getTrtcInstanceEvents && canViewTrtcRoomEvents && (
+          {(status === 1 || (status === 0 && !isBeforeStart)) && apis?.getTrtcRoomEventsSummary && canViewTrtcRoomEvents && (
             <Flex vertical className={style['member-area']}>
               <Flex align="center" justify="space-between">
                 <div className={style['member-title']}>{formatMessage({ id: 'TrtcRoomEvents' })}</div>

--- a/src/components/RoomEvents/README.md
+++ b/src/components/RoomEvents/README.md
@@ -2,7 +2,7 @@
 
 ### 概述
 
-房间情况展示组件，基于 TRTC 房间事件数据展示实际会议时长、成员在线摘要、设备信息、质量分析图表和事件时间线。可被会议详情或其他平台（如 unfolds）直接复用。
+房间情况展示组件，基于后端聚合摘要展示实际会议时长、成员在线摘要、设备信息、质量分析图表和事件时间线。可被会议详情或其他平台（如 unfolds）直接复用。
 
 
 ### 示例
@@ -10,12 +10,12 @@
 #### 示例代码
 
 - 基础用法
-- 传入 mock 房间事件与成员数据，展示房间概览、摘要与成员详情
+- 传入 mock 房间事件摘要与成员数据，展示房间概览、摘要与成员详情
 - _RoomEvents(@components/RoomEvents),_mockPreset(@root/mockPreset),remoteLoader(@kne/remote-loader)
 
 ```jsx
 const { default: RoomEvents } = _RoomEvents;
-const { default: preset, mockConferenceList, mockTrtcInstanceEvents } = _mockPreset;
+const { default: preset, mockConferenceList, mockTrtcRoomEventsSummary } = _mockPreset;
 const { createWithRemoteLoader } = remoteLoader;
 
 const conference = mockConferenceList.pageData[0];
@@ -32,7 +32,7 @@ const BaseExample = createWithRemoteLoader({
           name={conference.name}
           status={conference.status}
           members={conference.members}
-          events={mockTrtcInstanceEvents.pageData}
+          data={mockTrtcRoomEventsSummary}
         />
       </div>
     </PureGlobal>
@@ -44,7 +44,7 @@ render(<BaseExample />);
 ```
 
 - 空数据
-- 未传入事件时展示空状态
+- 未传入摘要时展示空状态
 - _RoomEvents(@components/RoomEvents),_mockPreset(@root/mockPreset),remoteLoader(@kne/remote-loader)
 
 ```jsx
@@ -61,7 +61,7 @@ const BaseExample = createWithRemoteLoader({
   return (
     <PureGlobal preset={preset}>
       <div style={{ width: 860, maxWidth: '100%', margin: '0 auto', padding: 16 }}>
-        <RoomEvents id={conference.id} name={conference.name} status={1} members={conference.members} events={[]} />
+        <RoomEvents id={conference.id} name={conference.name} status={1} members={conference.members} data={null} />
       </div>
     </PureGlobal>
   );
@@ -75,7 +75,7 @@ render(<BaseExample />);
 
 ### RoomEvents
 
-房间情况展示组件，基于 TRTC 房间事件数据展示实际会议时长、成员摘要、设备信息、质量分析与事件时间线。组件纯展示，不请求接口，可由宿主传入 `events` 数据后直接渲染，便于 unfolds 等平台复用。
+房间情况展示组件。基于后端聚合摘要展示实际会议时长、成员摘要、设备信息、质量分析与事件时间线。组件纯展示，不请求接口。
 
 #### 属性说明
 
@@ -84,18 +84,9 @@ render(<BaseExample />);
 | className | string | 否 | - | 自定义 CSS 类名 |
 | id | string | 否 | - | 房间/会议 ID，展示在概览区 |
 | name | string | 否 | - | 房间/会议名称，展示在概览区标题 |
-| status | number | 否 | - | 会议状态：`0` 进行中/待开始、`1` 已结束；已结束时若无退房/解散事件，会用最后一条事件时间推断实际结束时间 |
-| members | array | 否 | `[]` | 成员列表，用于名称映射与摘要统计，字段含 `id` / `nickname` / `email` |
-| events | array | 否 | `[]` | TRTC 房间事件列表，结构与 `getTrtcInstanceEvents` 返回的 `pageData` 一致 |
-
-#### events 单条结构（常用字段）
-
-| 字段名 | 类型 | 说明 |
-|--------|------|------|
-| id | string | 事件 ID |
-| code | string | 事件编码，如 `Client.enter`、`Client.network-quality`、`1001` |
-| time | string | 事件时间（ISO 字符串） |
-| payload | object | 事件载荷，含 `userId` / `reporterId` / `event` / `data` 等 |
+| status | number | 否 | - | 会议状态（兼容字段） |
+| members | array | 否 | `[]` | 成员列表，用于名称映射，字段含 `id` / `nickname` / `email` |
+| data | object | 否 | - | 后端房间事件聚合摘要（`getTrtcRoomEventsSummary`） |
 
 #### 远程调用示例（unfolds 等）
 
@@ -108,6 +99,6 @@ import RemoteLoader from '@kne/remote-loader';
   name={roomName}
   status={1}
   members={members}
-  events={events}
+  data={roomEventsSummary}
 />
 ```

--- a/src/components/RoomEvents/doc/api.md
+++ b/src/components/RoomEvents/doc/api.md
@@ -1,6 +1,6 @@
 ### RoomEvents
 
-房间情况展示组件，基于 TRTC 房间事件数据展示实际会议时长、成员摘要、设备信息、质量分析与事件时间线。组件纯展示，不请求接口，可由宿主传入 `events` 数据后直接渲染，便于 unfolds 等平台复用。
+房间情况展示组件。基于后端聚合摘要（`getTrtcRoomEventsSummary` / `open-api/roomEventsSummary`）展示实际会议时长、成员摘要、设备信息、质量分析、降采样图表与离散事件时间线。组件纯展示，不请求接口。
 
 #### 属性说明
 
@@ -9,18 +9,17 @@
 | className | string | 否 | - | 自定义 CSS 类名 |
 | id | string | 否 | - | 房间/会议 ID，展示在概览区 |
 | name | string | 否 | - | 房间/会议名称，展示在概览区标题 |
-| status | number | 否 | - | 会议状态：`0` 进行中/待开始、`1` 已结束；已结束时若无退房/解散事件，会用最后一条事件时间推断实际结束时间 |
-| members | array | 否 | `[]` | 成员列表，用于名称映射与摘要统计，字段含 `id` / `nickname` / `email` |
-| events | array | 否 | `[]` | TRTC 房间事件列表，结构与 `getTrtcInstanceEvents` 返回的 `pageData` 一致 |
+| status | number | 否 | - | 会议状态（兼容字段，实际结束时间以 `data.overview` 为准） |
+| members | array | 否 | `[]` | 成员列表，用于名称映射，字段含 `id` / `nickname` / `email` |
+| data | object | 否 | - | 后端房间事件聚合摘要 |
 
-#### events 单条结构（常用字段）
+#### data 结构（常用字段）
 
 | 字段名 | 类型 | 说明 |
 |--------|------|------|
-| id | string | 事件 ID |
-| code | string | 事件编码，如 `Client.enter`、`Client.network-quality`、`1001` |
-| time | string | 事件时间（ISO 字符串） |
-| payload | object | 事件载荷，含 `userId` / `reporterId` / `event` / `data` 等 |
+| overview | object | `actualStart` / `actualEnd` / `actualDurationSeconds` / `useLiveEnd` |
+| summary | object | `memberCount` / `onlineCount` / `networkIssueCount` / `deviceIssueCount` |
+| members | array | 按人聚合：`deviceInfo` / `analysis` / `charts` / `timeline` |
 
 #### 远程调用示例（unfolds 等）
 
@@ -33,6 +32,6 @@ import RemoteLoader from '@kne/remote-loader';
   name={roomName}
   status={1}
   members={members}
-  events={events}
+  data={roomEventsSummary}
 />
 ```

--- a/src/components/RoomEvents/doc/base.js
+++ b/src/components/RoomEvents/doc/base.js
@@ -1,5 +1,5 @@
 const { default: RoomEvents } = _RoomEvents;
-const { default: preset, mockConferenceList, mockTrtcInstanceEvents } = _mockPreset;
+const { default: preset, mockConferenceList, mockTrtcRoomEventsSummary } = _mockPreset;
 const { createWithRemoteLoader } = remoteLoader;
 
 const conference = mockConferenceList.pageData[0];
@@ -16,7 +16,7 @@ const BaseExample = createWithRemoteLoader({
           name={conference.name}
           status={conference.status}
           members={conference.members}
-          events={mockTrtcInstanceEvents.pageData}
+          data={mockTrtcRoomEventsSummary}
         />
       </div>
     </PureGlobal>

--- a/src/components/RoomEvents/doc/empty.js
+++ b/src/components/RoomEvents/doc/empty.js
@@ -11,7 +11,7 @@ const BaseExample = createWithRemoteLoader({
   return (
     <PureGlobal preset={preset}>
       <div style={{ width: 860, maxWidth: '100%', margin: '0 auto', padding: 16 }}>
-        <RoomEvents id={conference.id} name={conference.name} status={1} members={conference.members} events={[]} />
+        <RoomEvents id={conference.id} name={conference.name} status={1} members={conference.members} data={null} />
       </div>
     </PureGlobal>
   );

--- a/src/components/RoomEvents/doc/example.json
+++ b/src/components/RoomEvents/doc/example.json
@@ -3,7 +3,7 @@
   "list": [
     {
       "title": "基础用法",
-      "description": "传入 mock 房间事件与成员数据，展示房间概览、摘要与成员详情",
+      "description": "传入 mock 房间事件摘要与成员数据，展示房间概览、摘要与成员详情",
       "code": "./base.js",
       "scope": [
         {
@@ -22,7 +22,7 @@
     },
     {
       "title": "空数据",
-      "description": "未传入事件时展示空状态",
+      "description": "未传入摘要时展示空状态",
       "code": "./empty.js",
       "scope": [
         {

--- a/src/components/RoomEvents/index.js
+++ b/src/components/RoomEvents/index.js
@@ -3,86 +3,107 @@ import { Flex, Alert, Empty, Descriptions, Tabs } from 'antd';
 import { DesktopOutlined, UserOutlined, WifiOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import classnames from 'classnames';
-import get from 'lodash/get';
 import { defaultColors } from '@kne/react-box';
 import { UAParser } from 'ua-parser-js';
 import { useIntl } from '@kne/react-intl';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import withLocale from './withLocale';
 import style from './style.module.scss';
+
+const SERIES_LABEL_IDS = {
+  uplinkNetworkQuality: 'UplinkNetworkQuality',
+  downlinkNetworkQuality: 'DownlinkNetworkQuality',
+  rtt: 'RTT(ms)',
+  upLoss: 'UpLoss',
+  downLoss: 'DownLoss',
+  audioBitrate: 'AudioBitrate',
+  audioLevel: 'AudioLevelPercent',
+  videoBitrate: 'VideoBitrate',
+  frameRate: 'FrameRate'
+};
+
+const METRIC_LABEL_IDS = {
+  rtt: 'RttMetric',
+  packetLoss: 'PacketLoss',
+  frameRate: 'FrameRate',
+  audioLevel: 'AudioLevel'
+};
+
+const EVENT_CODE_IDS = {
+  'Client.enter': 'EventEnterRoom',
+  'Client.exit': 'EventExitRoom',
+  'Client.camera-open': 'EventCameraOpen',
+  'Client.camera-close': 'EventCameraClose',
+  'Client.microphone-open': 'EventMicrophoneOpen',
+  'Client.microphone-close': 'EventMicrophoneClose',
+  'Client.camera-switch': 'EventCameraSwitch',
+  'Client.microphone-switch': 'EventMicrophoneSwitch',
+  'Client.device-info': 'EventDeviceInfo',
+  'DescribeCallDetailInfo.User': 'EventUserInfo',
+  '103': 'EventRoomDismiss',
+  enter: 'EventEnterRoom',
+  exit: 'EventExitRoom'
+};
 
 const RoomEvents = createWithRemoteLoader({
   modules: ['components-core:InfoPage@Flow', 'components-thirdparty:Echart']
 })(
-  withLocale(({ remoteModules, className, id, name, status, members = [], events = [] }) => {
+  withLocale(({ remoteModules, className, id, name, status: _status, members = [], data }) => {
     const [Flow, Echart] = remoteModules;
     const { formatMessage } = useIntl();
     const [now, setNow] = useState(() => Date.now());
-    const sortedEvents = events.slice().sort((a, b) => dayjs(a.time).valueOf() - dayjs(b.time).valueOf());
+    const [activeMemberKey, setActiveMemberKey] = useState(null);
 
-    const getMemberName = member => {
-      return member?.nickname || member?.email || formatMessage({ id: 'DefaultUser' });
-    };
+    const overview = data?.overview || {};
+    const summary = data?.summary || {};
+    const memberSummaries = data?.members || [];
+
+    const getMemberName = member => member?.nickname || member?.email || formatMessage({ id: 'DefaultUser' });
     const getUserNameById = userId => {
       const member = members.find(item => String(item.id) === String(userId));
       if (member) {
         return getMemberName(member);
       }
+      const summaryMember = memberSummaries.find(item => String(item.userId) === String(userId));
+      if (summaryMember?.userId) {
+        return String(summaryMember.userId);
+      }
       return userId === '-' ? formatMessage({ id: 'DefaultUser' }) : userId;
     };
-    const getEventReporterId = event => {
-      const payload = event.payload || {};
-      return payload.reporterId || payload.event?.reporterId || payload.userId || payload.peerId || payload.event?.UserId || '-';
-    };
-    const getEventReporterName = event => {
-      return getUserNameById(getEventReporterId(event));
-    };
-    const getEventActorId = event => {
-      const payload = event.payload || {};
-      return payload.event?.userId || payload.event?.data?.userId || payload.peerId || payload.event?.UserId || payload.userId || '-';
-    };
-    const getEventActorName = event => {
-      return getUserNameById(getEventActorId(event));
-    };
-    const getMetricValue = (target, paths) => {
-      for (const path of paths) {
-        const value = get(target, path);
-        if (value !== undefined && value !== null && value !== '') {
-          return value;
-        }
+
+    const formatSeriesName = key => {
+      if (SERIES_LABEL_IDS[key] === 'RTT(ms)') {
+        return 'RTT(ms)';
       }
-      return undefined;
-    };
-    const toNumber = value => {
-      const numberValue = Number(value);
-      return Number.isFinite(numberValue) ? numberValue : undefined;
-    };
-    const formatIntegerMetric = value => {
-      const numberValue = toNumber(value);
-      return numberValue === undefined ? undefined : Math.round(numberValue);
-    };
-    const formatAudioLevelMetric = value => {
-      const numberValue = toNumber(value);
-      return numberValue === undefined ? undefined : Number((numberValue * 100).toFixed(2));
-    };
-    const getEventData = event => {
-      const payload = event.payload || {};
-      return payload.event?.data || payload.data || {};
-    };
-    const isDeviceInfoEvent = event => event.code === 'Client.device-info';
-    const isChartEvent = event => ['Client.network-quality', 'Client.statistics', 'DescribeCallDetailInfo.Metric'].includes(event.code);
-    const formatDeviceName = device => {
-      if (!device) {
-        return '-';
+      if (SERIES_LABEL_IDS[key] === 'AudioLevelPercent') {
+        return `${formatMessage({ id: 'AudioLevel' })}(%)`;
       }
-      return device.label || device.deviceId || '-';
-    };
-    const formatDeviceList = devices => {
-      if (!(Array.isArray(devices) && devices.length > 0)) {
-        return '-';
+      if (SERIES_LABEL_IDS[key]) {
+        return formatMessage({ id: SERIES_LABEL_IDS[key] });
       }
-      return devices.map((device, index) => <div key={device.deviceId || index}>{formatDeviceName(device)}</div>);
+      return key;
     };
+
+    const formatAnalysisMetric = metric => {
+      if (!metric) {
+        return '';
+      }
+      if (typeof metric === 'string') {
+        return metric;
+      }
+      const labelId = METRIC_LABEL_IDS[metric.key];
+      const label = labelId ? formatMessage({ id: labelId }) : metric.key;
+      return `${label} ${metric.value}`;
+    };
+
+    const formatEventType = code => {
+      const messageId = EVENT_CODE_IDS[code];
+      if (messageId) {
+        return formatMessage({ id: messageId });
+      }
+      return `${formatMessage({ id: 'EventCode' })}: ${code || '-'}`;
+    };
+
     const formatConnection = connection => {
       if (!connection) {
         return '-';
@@ -96,6 +117,7 @@ const RoomEvents = createWithRemoteLoader({
         .filter(Boolean)
         .join(' / ');
     };
+
     const formatBrowser = userAgent => {
       if (!userAgent) {
         return '-';
@@ -103,30 +125,26 @@ const RoomEvents = createWithRemoteLoader({
       const browser = new UAParser(userAgent).getBrowser();
       return [browser.name, browser.version].filter(Boolean).join(' ') || '-';
     };
-    const getDeviceInfoMap = eventList => {
-      const deviceEvents = eventList.filter(isDeviceInfoEvent);
-      const eventMap = new Map();
-      deviceEvents.forEach(event => {
-        eventMap.set(String(getEventReporterId(event)), event);
-      });
-      return eventMap;
+
+    const formatEventDateTime = value => {
+      if (!value) {
+        return '-';
+      }
+      const date = dayjs(value);
+      return date.isValid() ? date.format('YYYY-MM-DD HH:mm:ss') : '-';
     };
-    const getTimeLabels = data => {
-      return Array.from(new Set(data.map(event => dayjs(event.time).format('HH:mm:ss'))));
+
+    const formatActualDuration = seconds => {
+      const value = Number(seconds);
+      if (!Number.isFinite(value) || value < 0) {
+        return '-';
+      }
+      const hours = Math.floor(value / 3600);
+      const minutes = Math.floor((value % 3600) / 60);
+      const restSeconds = Math.floor(value % 60);
+      return [hours ? `${hours}h` : null, minutes ? `${minutes}m` : null, `${restSeconds}s`].filter(Boolean).join(' ');
     };
-    const createUserSeries = ({ data, labels, metrics }) => {
-      const userIds = Array.from(new Set(data.map(getEventReporterId)));
-      return userIds.flatMap(userId => {
-        const userData = data.filter(event => String(getEventReporterId(event)) === String(userId));
-        return metrics.map(metric => ({
-          name: metric.name,
-          data: labels.map(label => {
-            const target = userData.find(event => dayjs(event.time).format('HH:mm:ss') === label);
-            return target ? metric.getValue(target) : undefined;
-          })
-        }));
-      });
-    };
+
     const createLineChartOption = ({ labels, series, yAxisName }) => {
       return {
         color: Object.values(defaultColors),
@@ -141,387 +159,176 @@ const RoomEvents = createWithRemoteLoader({
           nameGap: 16,
           axisLabel: { margin: 12 }
         },
-        series: series.map(item => Object.assign({ type: 'line', smooth: true, connectNulls: true, showSymbol: false, lineStyle: { width: 1 } }, item))
-      };
-    };
-    const getNetworkQualityChart = eventList => {
-      const data = eventList.filter(event => event.code === 'Client.network-quality').sort((a, b) => dayjs(a.time).valueOf() - dayjs(b.time).valueOf());
-      if (data.length === 0) {
-        return null;
-      }
-      return createLineChartOption({
-        labels: getTimeLabels(data),
-        yAxisName: formatMessage({ id: 'QualityLevel' }),
-        series: createUserSeries({
-          data,
-          labels: getTimeLabels(data),
-          metrics: [
-            { name: formatMessage({ id: 'UplinkNetworkQuality' }), getValue: event => formatIntegerMetric(getEventData(event).uplinkNetworkQuality) },
-            { name: formatMessage({ id: 'DownlinkNetworkQuality' }), getValue: event => formatIntegerMetric(getEventData(event).downlinkNetworkQuality) }
-          ]
-        })
-      });
-    };
-    const getStatisticsCharts = eventList => {
-      const data = eventList.filter(event => event.code === 'Client.statistics').sort((a, b) => dayjs(a.time).valueOf() - dayjs(b.time).valueOf());
-      if (data.length === 0) {
-        return null;
-      }
-      const labels = getTimeLabels(data);
-      return {
-        network: createLineChartOption({
-          labels,
-          yAxisName: formatMessage({ id: 'MetricValue' }),
-          series: createUserSeries({
-            data,
-            labels,
-            metrics: [
-              { name: 'RTT(ms)', getValue: event => formatIntegerMetric(getMetricValue(getEventData(event), ['rtt'])) },
-              { name: formatMessage({ id: 'UpLoss' }), getValue: event => formatIntegerMetric(getMetricValue(getEventData(event), ['upLoss'])) },
-              { name: formatMessage({ id: 'DownLoss' }), getValue: event => formatIntegerMetric(getMetricValue(getEventData(event), ['downLoss'])) }
-            ]
-          })
-        }),
-        media: createLineChartOption({
-          labels,
-          yAxisName: formatMessage({ id: 'MetricValue' }),
-          series: createUserSeries({
-            data,
-            labels,
-            metrics: [
-              { name: formatMessage({ id: 'AudioBitrate' }), getValue: event => formatIntegerMetric(getMetricValue(getEventData(event), ['localStatistics.audio.bitrate'])) },
-              { name: `${formatMessage({ id: 'AudioLevel' })}(%)`, getValue: event => formatAudioLevelMetric(getMetricValue(getEventData(event), ['localStatistics.audio.audioLevel'])) },
-              { name: formatMessage({ id: 'VideoBitrate' }), getValue: event => formatIntegerMetric(getMetricValue(getEventData(event), ['localStatistics.video.0.bitrate'])) },
-              { name: formatMessage({ id: 'FrameRate' }), getValue: event => formatIntegerMetric(getMetricValue(getEventData(event), ['localStatistics.video.0.frameRate'])) }
-            ]
-          })
-        })
-      };
-    };
-    const getCallMetricChart = eventList => {
-      const metricEvents = eventList.filter(event => event.code === 'DescribeCallDetailInfo.Metric');
-      const points = metricEvents.flatMap(event => {
-        const payload = event.payload || {};
-        const data = payload.data || {};
-        return (data.Content || []).map(item => ({
-          time: item.Time,
-          value: formatIntegerMetric(item.Value),
-          name: data.DataType || payload.dataType
-        }));
-      });
-      if (points.length === 0) {
-        return null;
-      }
-      const labels = Array.from(new Set(points.map(item => dayjs(item.time * 1000).format('HH:mm:ss')))).sort();
-      const groupNames = Array.from(new Set(points.map(item => item.name)));
-      return createLineChartOption({
-        labels,
-        yAxisName: formatMessage({ id: 'MetricValue' }),
-        series: groupNames.map(metricName => ({
-          name: metricName,
-          data: labels.map(label => {
-            const point = points.find(item => item.name === metricName && dayjs(item.time * 1000).format('HH:mm:ss') === label);
-            return point?.value;
-          })
-        }))
-      });
-    };
-    const average = values => {
-      const list = values.map(toNumber).filter(value => typeof value === 'number' && Number.isFinite(value));
-      if (list.length === 0) {
-        return undefined;
-      }
-      return list.reduce((sum, value) => sum + value, 0) / list.length;
-    };
-    const getStatisticsAnalysis = eventList => {
-      const data = eventList.filter(event => event.code === 'Client.statistics');
-      const userIds = Array.from(new Set(data.map(getEventReporterId)));
-      return userIds
-        .map(userId => {
-          const userEvents = data.filter(event => String(getEventReporterId(event)) === String(userId));
-          const metrics = userEvents.map(getEventData);
-          const avgRtt = average(metrics.map(item => getMetricValue(item, ['rtt'])));
-          const maxRtt = Math.max(...metrics.map(item => toNumber(getMetricValue(item, ['rtt']))).filter(value => typeof value === 'number'));
-          const avgLoss = average(metrics.map(item => (Number(getMetricValue(item, ['upLoss']) || 0) + Number(getMetricValue(item, ['downLoss']) || 0)) / 2));
-          const avgFrameRate = average(metrics.map(item => getMetricValue(item, ['localStatistics.video.0.frameRate'])));
-          const avgAudioLevel = average(metrics.map(item => getMetricValue(item, ['localStatistics.audio.audioLevel'])));
-          const issues = [];
-          let type = 'success';
-          if ((avgRtt !== undefined && avgRtt > 150) || (maxRtt !== -Infinity && maxRtt > 300) || (avgLoss !== undefined && avgLoss > 5)) {
-            type = 'error';
-            issues.push(formatMessage({ id: 'NetworkBadAnalysis' }));
-          } else if ((avgRtt !== undefined && avgRtt > 100) || (avgLoss !== undefined && avgLoss > 0)) {
-            type = 'warning';
-            issues.push(formatMessage({ id: 'NetworkWarningAnalysis' }));
-          }
-          if (avgFrameRate !== undefined && avgFrameRate < 15) {
-            type = 'error';
-            issues.push(formatMessage({ id: 'FrameRateBadAnalysis' }));
-          } else if (avgFrameRate !== undefined && avgFrameRate < 20 && type !== 'error') {
-            type = 'warning';
-            issues.push(formatMessage({ id: 'FrameRateWarningAnalysis' }));
-          }
-          if (avgAudioLevel !== undefined && avgAudioLevel < 0.01) {
-            if (type !== 'error') {
-              type = 'warning';
+        series: series.map(item =>
+          Object.assign(
+            { type: 'line', smooth: true, connectNulls: true, showSymbol: false, lineStyle: { width: 1 } },
+            {
+              name: formatSeriesName(item.key),
+              data: item.data
             }
-            issues.push(formatMessage({ id: 'AudioLevelLowAnalysis' }));
-          } else if (avgAudioLevel !== undefined && avgAudioLevel > 0.2) {
-            if (type !== 'error') {
-              type = 'warning';
-            }
-            issues.push(formatMessage({ id: 'AudioLevelHighAnalysis' }));
-          }
-          return {
-            userId,
-            userName: getEventReporterName(userEvents[0]),
-            type,
-            summary: issues.length > 0 ? issues.join('；') : formatMessage({ id: 'QualityNormalAnalysis' }),
-            metrics: [
-              avgRtt !== undefined ? `RTT ${Math.round(avgRtt)}ms` : null,
-              avgLoss !== undefined ? `${formatMessage({ id: 'PacketLoss' })} ${Math.round(avgLoss)}%` : null,
-              avgFrameRate !== undefined ? `${formatMessage({ id: 'FrameRate' })} ${Math.round(avgFrameRate)}fps` : null,
-              avgAudioLevel !== undefined ? `${formatMessage({ id: 'AudioLevel' })} ${(avgAudioLevel * 100).toFixed(2)}%` : null
-            ].filter(Boolean)
-          };
-        })
-        .filter(item => item.metrics.length > 0);
-    };
-    const formatEventType = event => {
-      const payload = event.payload || {};
-      const eventType = payload.eventType || payload.recordType || payload.eventId || event.code;
-      const mapping = {
-        'Client.enter': formatMessage({ id: 'EventEnterRoom' }),
-        'Client.exit': formatMessage({ id: 'EventExitRoom' }),
-        'Client.network-quality': formatMessage({ id: 'EventNetworkQuality' }),
-        'Client.statistics': formatMessage({ id: 'EventStatistics' }),
-        'Client.camera-open': formatMessage({ id: 'EventCameraOpen' }),
-        'Client.camera-close': formatMessage({ id: 'EventCameraClose' }),
-        'Client.microphone-open': formatMessage({ id: 'EventMicrophoneOpen' }),
-        'Client.microphone-close': formatMessage({ id: 'EventMicrophoneClose' }),
-        'Client.camera-switch': formatMessage({ id: 'EventCameraSwitch' }),
-        'Client.microphone-switch': formatMessage({ id: 'EventMicrophoneSwitch' }),
-        'Client.device-info': formatMessage({ id: 'EventDeviceInfo' }),
-        'DescribeCallDetailInfo.User': formatMessage({ id: 'EventUserInfo' }),
-        'DescribeCallDetailInfo.Metric': formatMessage({ id: 'EventCallMetric' }),
-        '103': formatMessage({ id: 'EventRoomDismiss' }),
-        enter: formatMessage({ id: 'EventEnterRoom' }),
-        exit: formatMessage({ id: 'EventExitRoom' }),
-        user: formatMessage({ id: 'EventUserInfo' }),
-        metric: formatMessage({ id: 'EventCallMetric' })
-      };
-      return mapping[event.code] || mapping[String(eventType)] || `${formatMessage({ id: 'EventCode' })}: ${eventType || '-'}`;
-    };
-    const isEnterEvent = event => {
-      const payload = event.payload || {};
-      return (
-        event.code === 'Client.enter' ||
-        event.code === 'enter' ||
-        event.code === '1001' ||
-        payload.paramOne === 'enter' ||
-        payload.event?.ParamOne === 'enter'
-      );
-    };
-    const isExitEvent = event => {
-      const payload = event.payload || {};
-      return (
-        event.code === 'Client.exit' ||
-        event.code === 'exit' ||
-        event.code === '1002' ||
-        payload.paramOne === 'exit' ||
-        payload.event?.ParamOne === 'exit'
-      );
-    };
-    const isDismissEvent = event => {
-      const payload = event.payload || {};
-      return event.code === '103' || payload.eventType === 103 || payload.event?.EventId === 103;
-    };
-    const formatEventDateTime = value => {
-      if (!value) {
-        return '-';
-      }
-      const date = dayjs(value);
-      return date.isValid() ? date.format('YYYY-MM-DD HH:mm:ss') : '-';
-    };
-    const formatActualDuration = seconds => {
-      const value = Number(seconds);
-      if (!Number.isFinite(value) || value < 0) {
-        return '-';
-      }
-      const hours = Math.floor(value / 3600);
-      const minutes = Math.floor((value % 3600) / 60);
-      const restSeconds = Math.floor(value % 60);
-      return [hours ? `${hours}h` : null, minutes ? `${minutes}m` : null, `${restSeconds}s`].filter(Boolean).join(' ');
-    };
-    const getRoomActualTimeSummary = (eventList, currentTime = Date.now()) => {
-      const enterTimes = eventList.filter(isEnterEvent).map(event => dayjs(event.time).valueOf()).filter(Number.isFinite);
-      const actualStart = enterTimes.length > 0 ? Math.min(...enterTimes) : null;
-      let onlineCount = 0;
-      let roomEmptyAt = null;
-      let dismissAt = null;
-      eventList.forEach(event => {
-        const timeValue = dayjs(event.time).valueOf();
-        if (!Number.isFinite(timeValue)) {
-          return;
-        }
-        if (isEnterEvent(event)) {
-          onlineCount += 1;
-        }
-        if (isExitEvent(event)) {
-          onlineCount = Math.max(0, onlineCount - 1);
-          if (onlineCount === 0) {
-            roomEmptyAt = timeValue;
-          }
-        }
-        if (isDismissEvent(event)) {
-          dismissAt = timeValue;
-        }
-      });
-      let actualEnd = null;
-      let useLiveEnd = false;
-      if (roomEmptyAt != null || dismissAt != null) {
-        actualEnd = Math.max(roomEmptyAt || 0, dismissAt || 0) || null;
-      } else if (status === 1 && eventList.length > 0) {
-        const lastEventTime = dayjs(eventList[eventList.length - 1].time).valueOf();
-        actualEnd = Number.isFinite(lastEventTime) ? lastEventTime : null;
-      } else if (status !== 1 && actualStart != null) {
-        actualEnd = currentTime;
-        useLiveEnd = true;
-      }
-      const actualDurationSeconds =
-        actualStart != null && actualEnd != null && actualEnd >= actualStart ? Math.round((actualEnd - actualStart) / 1000) : null;
-      return {
-        actualStart,
-        actualEnd,
-        actualDurationSeconds,
-        useLiveEnd
-      };
-    };
-    const getMemberEventState = (userId, eventList) => {
-      const userEvents = eventList.filter(event => String(getEventReporterId(event)) === String(userId));
-      let online = false;
-      let cameraOpen = null;
-      let microphoneOpen = null;
-      let worstNetwork = 0;
-      userEvents.forEach(event => {
-        if (event.code === 'Client.enter' || event.code === 'enter') {
-          online = true;
-        }
-        if (event.code === 'Client.exit' || event.code === 'exit') {
-          online = false;
-        }
-        if (event.code === 'Client.camera-open') {
-          cameraOpen = true;
-        }
-        if (event.code === 'Client.camera-close') {
-          cameraOpen = false;
-        }
-        if (event.code === 'Client.microphone-open') {
-          microphoneOpen = true;
-        }
-        if (event.code === 'Client.microphone-close') {
-          microphoneOpen = false;
-        }
-        if (event.code === 'Client.network-quality') {
-          const data = getEventData(event);
-          const quality = Math.max(Number(data.uplinkNetworkQuality) || 0, Number(data.downlinkNetworkQuality) || 0);
-          if (quality > worstNetwork) {
-            worstNetwork = quality;
-          }
-        }
-      });
-      return { online, cameraOpen, microphoneOpen, worstNetwork };
-    };
-    const getRoomEventsSummary = eventList => {
-      const memberIds = members.map(member => String(member.id)).filter(Boolean);
-      const eventUserIds = Array.from(new Set(eventList.map(event => String(getEventReporterId(event))).filter(userId => userId && userId !== '-')));
-      const userIds = Array.from(new Set(memberIds.concat(eventUserIds)));
-      const networkIssueUserIds = new Set(
-        getStatisticsAnalysis(eventList)
-          .filter(item => item.type === 'error')
-          .map(item => String(item.userId))
-      );
-      let onlineCount = 0;
-      let networkIssueCount = 0;
-      let deviceIssueCount = 0;
-      userIds.forEach(userId => {
-        const memberState = getMemberEventState(userId, eventList);
-        if (memberState.online) {
-          onlineCount += 1;
-        }
-        if (memberState.worstNetwork >= 4 || networkIssueUserIds.has(String(userId))) {
-          networkIssueCount += 1;
-        }
-        if (memberState.cameraOpen === false || memberState.microphoneOpen === false) {
-          deviceIssueCount += 1;
-        }
-      });
-      return {
-        memberCount: members.length || userIds.length,
-        onlineCount,
-        networkIssueCount,
-        deviceIssueCount
+          )
+        )
       };
     };
 
-    const renderDeviceDescription = event => {
-      if (!event) {
+    const liveEndTime = useMemo(() => {
+      if (!overview.useLiveEnd || !overview.actualStart) {
+        return overview.actualEnd;
+      }
+      return new Date(now).toISOString();
+    }, [overview.useLiveEnd, overview.actualStart, overview.actualEnd, now]);
+
+    const liveDurationSeconds = useMemo(() => {
+      if (!overview.useLiveEnd || !overview.actualStart) {
+        return overview.actualDurationSeconds;
+      }
+      const start = dayjs(overview.actualStart).valueOf();
+      if (!Number.isFinite(start)) {
+        return overview.actualDurationSeconds;
+      }
+      return Math.round((now - start) / 1000);
+    }, [overview.useLiveEnd, overview.actualStart, overview.actualDurationSeconds, now]);
+
+    useEffect(() => {
+      if (!overview.useLiveEnd) {
+        return;
+      }
+      const timer = window.setInterval(() => {
+        setNow(Date.now());
+      }, 1000);
+      return () => window.clearInterval(timer);
+    }, [overview.useLiveEnd]);
+
+    const memberTabs = useMemo(() => {
+      const memberIds = new Set(members.map(member => String(member.id)));
+      const fromMembers = members.map(member => ({
+        key: String(member.id),
+        label: getMemberName(member)
+      }));
+      const extras = memberSummaries
+        .filter(item => !memberIds.has(String(item.userId)))
+        .map(item => ({
+          key: String(item.userId),
+          label: getUserNameById(item.userId)
+        }));
+      return fromMembers.concat(extras);
+    }, [members, memberSummaries]);
+
+    useEffect(() => {
+      if (memberTabs.length === 0) {
+        setActiveMemberKey(null);
+        return;
+      }
+      if (!activeMemberKey || !memberTabs.some(item => item.key === activeMemberKey)) {
+        setActiveMemberKey(memberTabs[0].key);
+      }
+    }, [memberTabs, activeMemberKey]);
+
+    const activeMemberSummary = memberSummaries.find(item => String(item.userId) === String(activeMemberKey));
+
+    const renderDeviceDescription = deviceInfo => {
+      if (!deviceInfo) {
         return <Empty description={formatMessage({ id: 'NoDeviceInfo' })} />;
       }
-      const data = getEventData(event);
-      const audioDevices = data.audioDevices || [];
-      const videoDevices = data.videoDevices || [];
-      const selectedAudio = audioDevices.find(device => device.deviceId === data.audioDeviceId);
-      const selectedVideo = videoDevices.find(device => device.deviceId === data.videoDeviceId);
       return (
         <div className={style['event-device-card']}>
           <Descriptions
             bordered
             size="small"
             column={{ xs: 1, sm: 1, md: 2 }}
-            title={`${getEventReporterName(event)} - ${dayjs(event.time).format('YYYY-MM-DD HH:mm:ss')}`}
+            title={`${getUserNameById(activeMemberKey)} - ${formatEventDateTime(deviceInfo.time)}`}
             items={[
-              { key: 'browser', label: formatMessage({ id: 'Browser' }), children: formatBrowser(data.userAgent) },
-              { key: 'platform', label: formatMessage({ id: 'Platform' }), children: data.platform || '-' },
-              { key: 'userAgent', label: formatMessage({ id: 'UserAgent' }), children: data.userAgent || '-', span: 2 },
-              { key: 'language', label: formatMessage({ id: 'Language' }), children: data.language || '-' },
+              { key: 'browser', label: formatMessage({ id: 'Browser' }), children: formatBrowser(deviceInfo.userAgent) },
+              { key: 'platform', label: formatMessage({ id: 'Platform' }), children: deviceInfo.platform || '-' },
+              { key: 'userAgent', label: formatMessage({ id: 'UserAgent' }), children: deviceInfo.userAgent || '-', span: 2 },
+              { key: 'language', label: formatMessage({ id: 'Language' }), children: deviceInfo.language || '-' },
               {
                 key: 'screen',
                 label: formatMessage({ id: 'Screen' }),
-                children: data.screenWidth && data.screenHeight ? `${data.screenWidth} * ${data.screenHeight}` : '-'
+                children:
+                  deviceInfo.screenWidth && deviceInfo.screenHeight ? `${deviceInfo.screenWidth} * ${deviceInfo.screenHeight}` : '-'
               },
-              { key: 'devicePixelRatio', label: formatMessage({ id: 'DevicePixelRatio' }), children: data.devicePixelRatio || '-' },
-              { key: 'connection', label: formatMessage({ id: 'NetworkConnection' }), children: formatConnection(data.connection), span: 2 },
-              { key: 'audioDeviceId', label: formatMessage({ id: 'SelectedAudioDevice' }), children: formatDeviceName(selectedAudio) },
-              { key: 'videoDeviceId', label: formatMessage({ id: 'SelectedVideoDevice' }), children: formatDeviceName(selectedVideo) },
-              { key: 'audioDevices', label: formatMessage({ id: 'AudioDeviceList' }), children: formatDeviceList(audioDevices), span: 2 },
-              { key: 'videoDevices', label: formatMessage({ id: 'VideoDeviceList' }), children: formatDeviceList(videoDevices), span: 2 }
+              { key: 'devicePixelRatio', label: formatMessage({ id: 'DevicePixelRatio' }), children: deviceInfo.devicePixelRatio || '-' },
+              { key: 'connection', label: formatMessage({ id: 'NetworkConnection' }), children: formatConnection(deviceInfo.connection), span: 2 },
+              { key: 'audioDeviceId', label: formatMessage({ id: 'SelectedAudioDevice' }), children: deviceInfo.selectedAudioLabel || '-' },
+              { key: 'videoDeviceId', label: formatMessage({ id: 'SelectedVideoDevice' }), children: deviceInfo.selectedVideoLabel || '-' },
+              {
+                key: 'audioDevices',
+                label: formatMessage({ id: 'AudioDeviceList' }),
+                children:
+                  deviceInfo.audioDeviceLabels?.length > 0
+                    ? deviceInfo.audioDeviceLabels.map((label, index) => <div key={`${label}-${index}`}>{label}</div>)
+                    : '-',
+                span: 2
+              },
+              {
+                key: 'videoDevices',
+                label: formatMessage({ id: 'VideoDeviceList' }),
+                children:
+                  deviceInfo.videoDeviceLabels?.length > 0
+                    ? deviceInfo.videoDeviceLabels.map((label, index) => <div key={`${label}-${index}`}>{label}</div>)
+                    : '-',
+                span: 2
+              }
             ]}
           />
         </div>
       );
     };
-    const renderStatisticsAnalysis = statisticsAnalysis => {
-      if (statisticsAnalysis.length === 0) {
+
+    const renderStatisticsAnalysis = analysis => {
+      if (!analysis) {
         return null;
       }
+      const message = (analysis.issueCodes || [])
+        .map(code => formatMessage({ id: code }))
+        .join('；');
       return (
         <div className={style['event-analysis-list']}>
           <div className={style['event-chart-title']}>{formatMessage({ id: 'QualityAnalysis' })}</div>
-          {statisticsAnalysis.map(item => (
-            <Alert
-              key={item.userId}
-              type={item.type}
-              showIcon
-              message={`${item.userName}: ${item.summary}`}
-              description={item.metrics.join(' / ')}
-            />
-          ))}
+          <Alert
+            type={analysis.type}
+            showIcon
+            message={`${getUserNameById(activeMemberKey)}: ${message || formatMessage({ id: 'QualityNormalAnalysis' })}`}
+            description={(analysis.metrics || []).map(formatAnalysisMetric).join(' / ')}
+          />
         </div>
       );
     };
-    const renderCharts = ({ networkQualityChart, statisticsCharts, callMetricChart }) => {
-      if (!(networkQualityChart || statisticsCharts || callMetricChart)) {
+
+    const renderCharts = charts => {
+      if (!charts) {
+        return null;
+      }
+      const networkQualityChart =
+        charts.networkQuality &&
+        createLineChartOption({
+          labels: charts.networkQuality.labels,
+          series: charts.networkQuality.series,
+          yAxisName: formatMessage({ id: 'QualityLevel' })
+        });
+      const statisticsNetwork =
+        charts.statisticsNetwork &&
+        createLineChartOption({
+          labels: charts.statisticsNetwork.labels,
+          series: charts.statisticsNetwork.series,
+          yAxisName: formatMessage({ id: 'MetricValue' })
+        });
+      const statisticsMedia =
+        charts.statisticsMedia &&
+        createLineChartOption({
+          labels: charts.statisticsMedia.labels,
+          series: charts.statisticsMedia.series,
+          yAxisName: formatMessage({ id: 'MetricValue' })
+        });
+      const callMetricChart =
+        charts.callMetric &&
+        createLineChartOption({
+          labels: charts.callMetric.labels,
+          series: charts.callMetric.series,
+          yAxisName: formatMessage({ id: 'MetricValue' })
+        });
+      if (!(networkQualityChart || statisticsNetwork || statisticsMedia || callMetricChart)) {
         return null;
       }
       return (
@@ -532,16 +339,16 @@ const RoomEvents = createWithRemoteLoader({
               <Echart style={{ height: 260 }} option={networkQualityChart} />
             </div>
           )}
-          {statisticsCharts?.network && (
+          {statisticsNetwork && (
             <div className={style['event-chart-card']}>
               <div className={style['event-chart-title']}>{formatMessage({ id: 'CallNetworkStatisticsChart' })}</div>
-              <Echart style={{ height: 280 }} option={statisticsCharts.network} />
+              <Echart style={{ height: 280 }} option={statisticsNetwork} />
             </div>
           )}
-          {statisticsCharts?.media && (
+          {statisticsMedia && (
             <div className={style['event-chart-card']}>
               <div className={style['event-chart-title']}>{formatMessage({ id: 'CallMediaStatisticsChart' })}</div>
-              <Echart style={{ height: 280 }} option={statisticsCharts.media} />
+              <Echart style={{ height: 280 }} option={statisticsMedia} />
             </div>
           )}
           {callMetricChart && (
@@ -553,23 +360,23 @@ const RoomEvents = createWithRemoteLoader({
         </div>
       );
     };
-    const isTimelineEvent = event => !isChartEvent(event) && !isDeviceInfoEvent(event);
-    const renderTimeline = timelineEvents => {
-      if (timelineEvents.length === 0) {
+
+    const renderTimeline = timeline => {
+      if (!(timeline && timeline.length > 0)) {
         return null;
       }
       return (
         <div className={style['event-timeline']}>
           <div className={style['event-chart-title']}>{formatMessage({ id: 'EventTimeline' })}</div>
           <Flow
-            current={timelineEvents.length - 1}
-            dataSource={timelineEvents}
+            current={timeline.length - 1}
+            dataSource={timeline}
             className={style['event-flow']}
             columns={[
               {
                 type: 'title',
                 name: 'code',
-                getValueOf: event => `${getEventActorName(event)} - ${formatEventType(event)}`
+                getValueOf: item => `${getUserNameById(item.actorUserId)} - ${formatEventType(item.code)}`
               },
               {
                 type: 'subTitle',
@@ -581,57 +388,33 @@ const RoomEvents = createWithRemoteLoader({
         </div>
       );
     };
-    const renderMemberInfo = ({ userId, deviceInfoMap, eventList }) => {
-      const memberEvents = eventList.filter(event => String(getEventReporterId(event)) === String(userId));
-      const timelineEvents = memberEvents.filter(isTimelineEvent);
-      const statisticsAnalysis = getStatisticsAnalysis(memberEvents);
-      const networkQualityChart = getNetworkQualityChart(memberEvents);
-      const statisticsCharts = getStatisticsCharts(memberEvents);
-      const callMetricChart = getCallMetricChart(memberEvents);
+
+    const renderMemberInfo = memberSummary => {
+      if (!memberSummary) {
+        return <Empty description={formatMessage({ id: 'NoMemberEventInfo' })} />;
+      }
       const hasMemberData =
-        deviceInfoMap.has(String(userId)) || statisticsAnalysis.length > 0 || networkQualityChart || statisticsCharts || callMetricChart || timelineEvents.length > 0;
+        memberSummary.deviceInfo ||
+        memberSummary.analysis ||
+        memberSummary.charts?.networkQuality ||
+        memberSummary.charts?.statisticsNetwork ||
+        memberSummary.charts?.statisticsMedia ||
+        memberSummary.charts?.callMetric ||
+        (memberSummary.timeline || []).length > 0;
       if (!hasMemberData) {
         return <Empty description={formatMessage({ id: 'NoMemberEventInfo' })} />;
       }
       return (
         <Flex vertical gap={12}>
-          {renderDeviceDescription(deviceInfoMap.get(String(userId)))}
-          {renderStatisticsAnalysis(statisticsAnalysis)}
-          {renderCharts({ networkQualityChart, statisticsCharts, callMetricChart })}
-          {renderTimeline(timelineEvents)}
+          {renderDeviceDescription(memberSummary.deviceInfo)}
+          {renderStatisticsAnalysis(memberSummary.analysis)}
+          {renderCharts(memberSummary.charts)}
+          {renderTimeline(memberSummary.timeline)}
         </Flex>
       );
     };
-    const renderMemberInfoTabs = ({ eventList, deviceInfoMap }) => {
-      const memberTabs = members.map(member => ({
-        key: String(member.id),
-        label: getMemberName(member),
-        children: renderMemberInfo({ userId: member.id, deviceInfoMap, eventList })
-      }));
-      const memberIds = new Set(members.map(member => String(member.id)));
-      const eventUserIds = Array.from(new Set(eventList.map(event => String(getEventReporterId(event)))));
-      const extraTabs = eventUserIds
-        .filter(userId => !memberIds.has(String(userId)))
-        .map(userId => {
-          const event = eventList.find(item => String(getEventReporterId(item)) === String(userId));
-          return {
-            key: String(userId),
-            label: getEventReporterName(event),
-            children: renderMemberInfo({ userId, deviceInfoMap, eventList })
-          };
-        });
-      const items = memberTabs.concat(extraTabs);
-      if (items.length === 0) {
-        return null;
-      }
-      return (
-        <div className={style['event-device-info']}>
-          <div className={style['event-chart-title']}>{formatMessage({ id: 'MemberEventInfo' })}</div>
-          <Tabs className={style['event-device-tabs']} size="small" items={items} />
-        </div>
-      );
-    };
-    const renderRoomEventsOverview = timeSummary => {
+
+    const renderRoomEventsOverview = () => {
       return (
         <div className={style['event-overview']}>
           <Flex justify="space-between" align="flex-start" gap={12} wrap>
@@ -648,51 +431,52 @@ const RoomEvents = createWithRemoteLoader({
               {
                 key: 'actualStart',
                 label: formatMessage({ id: 'RoomActualStartTime' }),
-                children: formatEventDateTime(timeSummary.actualStart)
+                children: formatEventDateTime(overview.actualStart)
               },
               {
                 key: 'actualEnd',
                 label: formatMessage({ id: 'RoomActualEndTime' }),
-                children: formatEventDateTime(timeSummary.actualEnd)
+                children: formatEventDateTime(liveEndTime)
               },
               {
                 key: 'actualDuration',
                 label: formatMessage({ id: 'RoomActualDuration' }),
-                children: formatActualDuration(timeSummary.actualDurationSeconds)
+                children: formatActualDuration(liveDurationSeconds)
               }
             ]}
           />
         </div>
       );
     };
-    const renderRoomEventsSummary = summary => {
+
+    const renderRoomEventsSummary = () => {
       const items = [
         {
           key: 'member',
           icon: <UserOutlined />,
           label: formatMessage({ id: 'RoomSummaryMemberCount' }),
-          value: summary.memberCount,
+          value: summary.memberCount ?? 0,
           status: 'default'
         },
         {
           key: 'online',
           icon: <UserOutlined />,
           label: formatMessage({ id: 'RoomSummaryOnlineCount' }),
-          value: summary.onlineCount,
+          value: summary.onlineCount ?? 0,
           status: 'success'
         },
         {
           key: 'network',
           icon: <WifiOutlined />,
           label: formatMessage({ id: 'RoomSummaryNetworkIssues' }),
-          value: summary.networkIssueCount,
+          value: summary.networkIssueCount ?? 0,
           status: summary.networkIssueCount ? 'error' : 'success'
         },
         {
           key: 'device',
           icon: <DesktopOutlined />,
           label: formatMessage({ id: 'RoomSummaryDeviceIssues' }),
-          value: summary.deviceIssueCount,
+          value: summary.deviceIssueCount ?? 0,
           status: summary.deviceIssueCount ? 'warning' : 'success'
         }
       ];
@@ -711,19 +495,21 @@ const RoomEvents = createWithRemoteLoader({
       );
     };
 
-    const timeSummary = getRoomActualTimeSummary(sortedEvents, now);
+    const hasContent =
+      overview.actualStart ||
+      summary.memberCount > 0 ||
+      memberSummaries.some(
+        item =>
+          item.deviceInfo ||
+          item.analysis ||
+          item.charts?.networkQuality ||
+          item.charts?.statisticsNetwork ||
+          item.charts?.statisticsMedia ||
+          item.charts?.callMetric ||
+          (item.timeline || []).length > 0
+      );
 
-    useEffect(() => {
-      if (!timeSummary.useLiveEnd) {
-        return;
-      }
-      const timer = window.setInterval(() => {
-        setNow(Date.now());
-      }, 1000);
-      return () => window.clearInterval(timer);
-    }, [timeSummary.useLiveEnd]);
-
-    if (sortedEvents.length === 0) {
+    if (!data || !hasContent) {
       return (
         <div className={classnames(className, style['room-events'])}>
           <Empty description={formatMessage({ id: 'NoTrtcRoomEvents' })} />
@@ -731,15 +517,27 @@ const RoomEvents = createWithRemoteLoader({
       );
     }
 
-    const deviceInfoMap = getDeviceInfoMap(sortedEvents);
-    const summary = getRoomEventsSummary(sortedEvents);
-
     return (
       <div className={classnames(className, style['room-events'])}>
         <Flex vertical gap={16}>
-          {renderRoomEventsOverview(timeSummary)}
-          {renderRoomEventsSummary(summary)}
-          {renderMemberInfoTabs({ eventList: sortedEvents, deviceInfoMap })}
+          {renderRoomEventsOverview()}
+          {renderRoomEventsSummary()}
+          {memberTabs.length > 0 && (
+            <div className={style['event-device-info']}>
+              <div className={style['event-chart-title']}>{formatMessage({ id: 'MemberEventInfo' })}</div>
+              <Tabs
+                className={style['event-device-tabs']}
+                size="small"
+                activeKey={activeMemberKey || undefined}
+                onChange={setActiveMemberKey}
+                items={memberTabs.map(item => ({
+                  key: item.key,
+                  label: item.label,
+                  children: String(item.key) === String(activeMemberKey) ? renderMemberInfo(activeMemberSummary) : null
+                }))}
+              />
+            </div>
+          )}
         </Flex>
       </div>
     );

--- a/src/components/RoomEvents/locale/en-US.js
+++ b/src/components/RoomEvents/locale/en-US.js
@@ -26,6 +26,7 @@ const locale = {
   AudioLevelLowAnalysis: 'Audio level is low and may be hard to hear',
   AudioLevelHighAnalysis: 'Audio level is high and may include noise or clipping',
   PacketLoss: 'Packet Loss',
+  RttMetric: 'RTT',
   AudioLevel: 'Audio Level',
   EventUser: 'User',
   EventCode: 'Event',

--- a/src/components/RoomEvents/locale/zh-CN.js
+++ b/src/components/RoomEvents/locale/zh-CN.js
@@ -26,6 +26,7 @@ const locale = {
   AudioLevelLowAnalysis: '音量偏低，可能听不清',
   AudioLevelHighAnalysis: '音量偏高，可能存在噪音或爆音',
   PacketLoss: '丢包率',
+  RttMetric: 'RTT',
   AudioLevel: '音量大小',
   EventUser: '用户',
   EventCode: '事件',

--- a/src/mockPreset/index.js
+++ b/src/mockPreset/index.js
@@ -219,6 +219,11 @@ const apis = merge({}, baseApis, {
       loader: () => {
         return import('./trtc-instance-events.json').then(({ default: data }) => data);
       }
+    },
+    getTrtcRoomEventsSummary: {
+      loader: () => {
+        return import('./trtc-room-events-summary.json').then(({ default: data }) => data);
+      }
     }
   },
   file: {
@@ -258,4 +263,5 @@ export { default as mockUserInfo } from './user-info.json';
 export { default as mockInviteData } from './invite-data.json';
 export { default as mockAiTranscriptionContent } from './ai-transcription-content.json';
 export { default as mockTrtcInstanceEvents } from './trtc-instance-events.json';
+export { default as mockTrtcRoomEventsSummary } from './trtc-room-events-summary.json';
 export default preset;

--- a/src/mockPreset/trtc-room-events-summary.json
+++ b/src/mockPreset/trtc-room-events-summary.json
@@ -1,0 +1,90 @@
+{
+  "overview": {
+    "actualStart": "2024-01-15T10:00:00.000Z",
+    "actualEnd": "2024-01-15T10:30:00.000Z",
+    "actualDurationSeconds": 1800,
+    "useLiveEnd": false
+  },
+  "summary": {
+    "memberCount": 2,
+    "onlineCount": 0,
+    "networkIssueCount": 0,
+    "deviceIssueCount": 0
+  },
+  "members": [
+    {
+      "userId": "member-1",
+      "deviceInfo": {
+        "time": "2024-01-15T10:00:05.000Z",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "platform": "MacIntel",
+        "language": "zh-CN",
+        "screenWidth": 1440,
+        "screenHeight": 900,
+        "devicePixelRatio": 2,
+        "connection": { "effectiveType": "4g", "downlink": 10, "rtt": 50 },
+        "selectedAudioLabel": "Built-in Microphone",
+        "selectedVideoLabel": "FaceTime HD Camera",
+        "audioDeviceLabels": ["Built-in Microphone"],
+        "videoDeviceLabels": ["FaceTime HD Camera"]
+      },
+      "analysis": {
+        "type": "success",
+        "issueCodes": ["QualityNormalAnalysis"],
+        "metrics": [
+          { "key": "rtt", "value": "45ms" },
+          { "key": "packetLoss", "value": "0%" },
+          { "key": "frameRate", "value": "24fps" },
+          { "key": "audioLevel", "value": "8.50%" }
+        ]
+      },
+      "charts": {
+        "networkQuality": {
+          "labels": ["10:00:10", "10:10:00", "10:20:00", "10:29:50"],
+          "series": [
+            { "key": "uplinkNetworkQuality", "data": [1, 1, 2, 1] },
+            { "key": "downlinkNetworkQuality", "data": [1, 2, 1, 1] }
+          ]
+        },
+        "statisticsNetwork": {
+          "labels": ["10:00:10", "10:10:00", "10:20:00", "10:29:50"],
+          "series": [
+            { "key": "rtt", "data": [40, 48, 55, 42] },
+            { "key": "upLoss", "data": [0, 0, 1, 0] },
+            { "key": "downLoss", "data": [0, 1, 0, 0] }
+          ]
+        },
+        "statisticsMedia": {
+          "labels": ["10:00:10", "10:10:00", "10:20:00", "10:29:50"],
+          "series": [
+            { "key": "audioBitrate", "data": [32, 34, 33, 32] },
+            { "key": "audioLevel", "data": [8.2, 9.1, 7.5, 8.0] },
+            { "key": "videoBitrate", "data": [800, 820, 780, 810] },
+            { "key": "frameRate", "data": [24, 25, 23, 24] }
+          ]
+        },
+        "callMetric": null
+      },
+      "timeline": [
+        { "time": "2024-01-15T10:00:00.000Z", "code": "Client.enter", "actorUserId": "member-1" },
+        { "time": "2024-01-15T10:00:08.000Z", "code": "Client.camera-open", "actorUserId": "member-1" },
+        { "time": "2024-01-15T10:30:00.000Z", "code": "Client.exit", "actorUserId": "member-1" }
+      ]
+    },
+    {
+      "userId": "member-2",
+      "deviceInfo": null,
+      "analysis": null,
+      "charts": {
+        "networkQuality": null,
+        "statisticsNetwork": null,
+        "statisticsMedia": null,
+        "callMetric": null
+      },
+      "timeline": [
+        { "time": "2024-01-15T10:01:00.000Z", "code": "Client.enter", "actorUserId": "member-2" },
+        { "time": "2024-01-15T10:28:00.000Z", "code": "Client.exit", "actorUserId": "member-2" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
打开房间事件不再全量翻页与前端重算图表，改为请求 summary 并懒渲染成员 Tab，避免长会议卡死。